### PR TITLE
Use npx cc-brain load instead of hardcoded bun path

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -5,7 +5,7 @@
       "hooks": [
         {
           "type": "command",
-          "command": "bun \"$CLAUDE_PROJECT_DIR/src/loader.js\"",
+          "command": "npx cc-brain load",
           "timeout": 5,
           "statusMessage": "Loading brain..."
         }

--- a/scripts/install.js
+++ b/scripts/install.js
@@ -66,9 +66,8 @@ if (existsSync(settingsPath)) {
 // Read our hooks config
 const hooks = JSON.parse(readFileSync(join(PROJECT_ROOT, 'hooks', 'hooks.json'), 'utf-8'));
 
-// Update loader path to absolute (forward slashes for cross-platform)
-const loaderPath = join(PROJECT_ROOT, 'src', 'loader.js').replace(/\\/g, '/');
-hooks.SessionStart[0].hooks[0].command = `bun "${loaderPath}"`;
+// Use npx to resolve package at runtime (works regardless of install location)
+hooks.SessionStart[0].hooks[0].command = 'npx cc-brain load';
 
 // Merge hooks — preserve user's other hooks, replace/append ours
 function isCcBrainHook(entry) {


### PR DESCRIPTION
## Summary
- Use `npx cc-brain load` instead of hardcoding bun path at install time
- Update hooks.json template to match
- Fix test helpers to find bun in common locations (~/.bun/bin/)

Fixes #3

## Test plan
- [x] All 62 tests pass
- [ ] Fresh install works correctly
- [ ] Hook loads brain on session start