### PR TITLE
Fix PreCompact duplicate hook detection

### DIFF
--- a/scripts/install.js
+++ b/scripts/install.js
@@ -82,7 +82,8 @@ function isCcBrainHook(entry) {
   if (!entry || !entry.hooks) return false;
   return entry.hooks.some(h =>
     (h.command && (h.command.includes('cc-brain') || h.command.includes('loader.js'))) ||
-    (h.prompt && h.prompt.includes('structured saver'))
+    (h.prompt && h.prompt.includes('structured saver')) ||
+    (h.statusMessage && h.statusMessage.includes('brain'))
   );
 }
 

--- a/scripts/uninstall.js
+++ b/scripts/uninstall.js
@@ -24,7 +24,8 @@ function isCcBrainHook(entry) {
   if (!entry || !entry.hooks) return false;
   return entry.hooks.some(h =>
     (h.command && (h.command.includes('cc-brain') || h.command.includes('loader.js'))) ||
-    (h.prompt && h.prompt.includes('structured saver'))
+    (h.prompt && h.prompt.includes('structured saver')) ||
+    (h.statusMessage && h.statusMessage.includes('brain'))
   );
 }
 


### PR DESCRIPTION
## Summary
- `isCcBrainHook` failed to match agent-type hooks missing the `prompt` field, causing broken duplicates to survive reinstalls
- Added `statusMessage` check as a fallback identifier in both `install.js` and `uninstall.js`

## Test plan
- [ ] Run installer twice — verify no duplicate PreCompact entries
- [ ] Verify broken prompt-less hooks are cleaned up on reinstall
- [ ] Verify uninstall removes all cc-brain hooks including malformed ones

Closes #6